### PR TITLE
Provide connections even with shortcut

### DIFF
--- a/pyiron_workflow/simple_workflow.py
+++ b/pyiron_workflow/simple_workflow.py
@@ -338,7 +338,21 @@ class DataElement:
 
     @property
     def connections(self):
-        return [Connection(self.value.node, self.value.label)]
+        if not self.connected:
+            return []
+        upstream_node: Node
+        upstream_port_lable: str
+        if isinstance(self.value, Port):
+            upstream_node = self.value.node
+            upstream_port_label = self.value.label
+        elif isinstance(self.value, Node):
+            if self.type == "Node":
+                raise NotImplementedError(
+                    "Cf. https://github.com/JNmpi/pyiron_core/issues/19"
+                )
+            upstream_node = self.value
+            upstream_port_label = self.value.inputs.data[PORT_LABEL][0]
+        return [Connection(upstream_node, upstream_port_label)]
 
     def type_hint(self, v):
         import numpy

--- a/tests/integration/test_hashing.py
+++ b/tests/integration/test_hashing.py
@@ -1,0 +1,30 @@
+import unittest
+
+import pyiron_database.instance_database as idb
+import pyiron_workflow as pwf
+
+
+@pwf.as_function_node
+def PassThrough(x):
+    return x
+
+
+class TestHashing(unittest.TestCase):
+
+    def test_node_connections(self):
+        wf_port = pwf.Workflow("hash_wf_steps")
+        wf_port.n1 = PassThrough(0)
+        wf_port.n2 = PassThrough(wf_port.n1.outputs.x)
+        wf_port.run()
+
+        wf_node = pwf.Workflow("hash_wf_steps")
+        wf_node.n1 = PassThrough(0)
+        wf_node.n2 = PassThrough(wf_node.n1)
+        wf_node.run()
+
+        self.assertEqual(
+            idb.node.node_inputs_to_jsongroup(wf_port.n2).data["x"],
+            idb.node.node_inputs_to_jsongroup(wf_node.n2).data["x"],
+            msg="The hash should be accessible and the same regardless of whether we "
+            "exploit the connect-directly-to-(single-output)-node shortcut",
+        )


### PR DESCRIPTION
The connection formation already raises an error when we try to provide a node directly as a connection but that node has multiple ports.

This closes #18, which has the knock-on effect of also resolving #17. Regarding the connectedness of functional nodes (#18), this PR remains agnostic and raises a `NotImplementedError`.