### PR TITLE
:fire:Handle macros exploiting single returns

### DIFF
--- a/pyiron_workflow/simple_workflow.py
+++ b/pyiron_workflow/simple_workflow.py
@@ -610,10 +610,15 @@ class Node:
         self._validate_input()
         if self.node_type in ["macro_node", "graph"]:
             subgraph_return = self._run()  # initialize the workflow (do not run it)
-            returned_ports = (
+            return_tuple = (
                 subgraph_return
                 if isinstance(subgraph_return, tuple)
                 else (subgraph_return,)
+            )
+            returned_ports = tuple(
+                p if isinstance(p, Port)
+                else p.outputs.__getattr__(p.outputs.data["label"][0])
+                for p in return_tuple
             )
             self._wf_macro = returned_ports[0].node._workflow
             self._wf_macro.run()  # Now run it


### PR DESCRIPTION
Hotfix for https://github.com/JNmpi/pyiron_core/pull/5. 

Fixes a book-keeping bug where running the macro was always expecting ports to get returned, but we are allowed to exploit the fact that nodes returning a single value may be used in lieu of their output port -- i.e. this doesn't work without this patch:

```python
@as_function_node
def PassThrough(x):
    return x

@as_macro_node(["by_channel", "by_node"])
def PassThroughMacro(x):
    wf = Workflow("subgraph")
    wf.p1 = PassThrough(x)
    wf.p2 = PassThrough(wf.p1)
    return wf.p1.outputs.x, wf.p2
```