### PR TITLE
Allow multiple groups in the same graph

### DIFF
--- a/pyiron_workflow/graph/base.py
+++ b/pyiron_workflow/graph/base.py
@@ -1577,7 +1577,6 @@ def _get_subgraph(graph: Graph, node_indices, label=None) -> Graph:
     for subgraph_node in graph.nodes.iloc(node_indices):
         # print(f"Collapsing node {subgraph_node}", type(subgraph_node))
         graph.nodes[subgraph_node].expanded = False
-    graph = get_updated_graph(graph)
 
     edges = graph.edges
     subgraph_nodes = graph.nodes.iloc(node_indices)

--- a/tests/integration/test_usage.py
+++ b/tests/integration/test_usage.py
@@ -42,3 +42,29 @@ class TestUsage(unittest.TestCase):
                 msg="Just verifying the group is also operational"
             )
             print(g.nodes["subgraph"].node._code)
+
+    def test_multiple_groups(self):
+        wf = pwf.Workflow("multiple_groups")
+        wf.m1 = nodes.PassThrough(0)
+        wf.m2 = nodes.PassThrough(wf.m1)
+        wf.n1 = nodes.PassThrough(1)
+        wf.n2 = nodes.PassThrough(wf.n1)
+
+        g = base.get_full_graph_from_wf(wf)
+
+        m_ids = base._node_labels_to_node_ids(g, ["m1", "m2"])
+        g = base.create_group(g, m_ids, label="m_subgraph")
+
+        n_ids = base._node_labels_to_node_ids(g, ["n1", "n2"])
+        g = base.create_group(g, n_ids, label="n_subgraph")
+
+        self.assertEqual(
+            0,
+            base.pull_node(g, "m_subgraph"),
+            msg="Both groups should be pullable",
+        )
+        self.assertEqual(
+            1,
+            base.pull_node(g, "n_subgraph"),
+            msg="Both groups should be pullable",
+        )


### PR DESCRIPTION
By not updating the graph during subgraph construction.

And test that this lets us have multiple groups in the same graph.

Because `_get_subgraph` is also used in `_find_input_nodes` and thus `pull_node`, there's a chance this has some side effect, but I can't positively find any.

Closes #30 