### PR TITLE
Test edge shorthand

### DIFF
--- a/tests/unit/test_simple_workflow.py
+++ b/tests/unit/test_simple_workflow.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 
 from static.nodes import PassThrough, PassThroughMacro
 
+
 @as_function_node
 def test_func(a: int, b: int = 1):
     result = a + b
@@ -32,14 +33,14 @@ class TestSimpleWorkflow(unittest.TestCase):
 
     def test_function_node_creation(self):
         node = test_func()
-        inp_labels = node.inputs.data['label']
-        out_labels = node.outputs.data['label']
-        ready = node.inputs.data['ready']
+        inp_labels = node.inputs.data["label"]
+        out_labels = node.outputs.data["label"]
+        ready = node.inputs.data["ready"]
         self.assertIsInstance(node, Node)
         self.assertEqual(node.n_out_labels, 1)
-        self.assertEqual(inp_labels, ['a', 'b'])
+        self.assertEqual(inp_labels, ["a", "b"])
         self.assertEqual(ready, [False, True])
-        self.assertEqual(out_labels, ['result'])
+        self.assertEqual(out_labels, ["result"])
         # self.assertEqual(node._func, test_func)
 
     def test_make_node_decorator(self):
@@ -92,7 +93,7 @@ class TestSimpleWorkflow(unittest.TestCase):
             (42, 42),
             out,
             msg="the macro should be runnable and should allow channel-based and "
-                "node-based (with single-returns) output formats"
+            "node-based (with single-returns) output formats",
         )
 
     # def test_node_with_libpath(self):


### PR DESCRIPTION
This is a feature @JNmpi already added, but I had been hoping it would exist and so I'm just adding a test to ensure it sticks around. It's just shorthand for adding edges to the virtual nodes based off their group:

```python
import pyiron_workflow as pwf
from pyiron_workflow.graph import base

@pwf.as_function_node
def AddOne(x):
    y = x + 1
    return y

wf = pwf.Workflow("mywf")
wf.n1 = AddOne(0)
wf.n2 = AddOne()

g = base.get_full_graph_from_wf(wf)
g = base.create_group(g, [0], label="subgraph")


# g = base.add_edge(g, "va_o_subgraph__n1__y", "n2", "x", "x")
g = base.add_edge(g, "subgraph", "n2", "n1__y", "x")  # Equivalent shorthand

print(base.pull_node(base.get_updated_graph(g), "n2"))
```