### PR TITLE
Expose pyiron_nodes as nodes

### DIFF
--- a/notebooks/running/cecam.ipynb
+++ b/notebooks/running/cecam.ipynb
@@ -135,7 +135,7 @@
     "from sqlalchemy import orm\n",
     "\n",
     "\n",
-    "import pyiron_core.pyiron_nodes as pyiron_nodes\n",
+    "from pyiron_core import nodes\n",
     "from pyiron_core.pyiron_workflow.api import graph as base, simple_workflow as pwf, gui"
    ],
    "id": "917d62ed85a61549"
@@ -342,56 +342,12 @@
    "id": "f7bc0cf392cbd7fe"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f4f43abb-a053-4b81-8856-e96b559b76e7",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:03.834657Z",
-     "start_time": "2025-05-16T23:04:03.832021Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[2, 3, 1]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "base._find_input_nodes(base._remove_node_inputs(graph), 1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "cbb55e5e-26ce-4c93-a0bb-7c1987b2cb68",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:03.998370Z",
-     "start_time": "2025-05-16T23:04:03.996185Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<function pyiron_nodes.local_workflows.test.BulkStaticEnergy(name: str, a: float = None, store: bool = True, _db=None) -> float>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pyiron_nodes.local_workflows.test.BulkStaticEnergy"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "base._find_input_nodes(base._remove_node_inputs(graph), 1)",
+   "id": "c1059979a9fae5d7"
   },
   {
    "metadata": {},
@@ -402,15 +358,15 @@
     "@pwf.as_function_node(\"energy\")\n",
     "def BulkStaticEnergy(name: str, a: float = None):\n",
     "\n",
+    "    from pyiron_core import nodes\n",
     "    from pyiron_core.pyiron_workflow import Workflow\n",
-    "    import pyiron_core.pyiron_nodes as pyiron_nodes\n",
     "\n",
     "    wf = Workflow('subgraph')\n",
     "\n",
-    "    wf.Bulk = pyiron_nodes.atomistic.structure.build.Bulk(name=name, a=a) \n",
-    "    wf.M3GNet = pyiron_nodes.atomistic.engine.ase.M3GNet() \n",
-    "    wf.Static = pyiron_nodes.atomistic.calculator.ase.Static(structure=wf.Bulk, engine=wf.M3GNet) \n",
-    "    wf.GetEnergyLast = pyiron_nodes.atomistic.calculator.output.GetEnergyLast(calculator=wf.Static) \n",
+    "    wf.Bulk = nodes.atomistic.structure.build.Bulk(name=name, a=a)\n",
+    "    wf.M3GNet = nodes.atomistic.engine.ase.M3GNet()\n",
+    "    wf.Static = nodes.atomistic.calculator.ase.Static(structure=wf.Bulk, engine=wf.M3GNet)\n",
+    "    wf.GetEnergyLast = nodes.atomistic.calculator.output.GetEnergyLast(calculator=wf.Static)\n",
     "\n",
     "    out = wf.GetEnergyLast.pull()\n",
     "\n",
@@ -418,7 +374,7 @@
     "\n",
     "    # return wf.GetEnergyLast.outputs.energy_last"
    ],
-   "id": "a537530638a22c84"
+   "id": "e69fc213b02a3f2c"
   },
   {
    "metadata": {},
@@ -429,19 +385,19 @@
     "@pwf.as_macro_node([\"BulkStaticEnergy\", \"BulkStructure\"])\n",
     "def BulkStaticEnergy(name: str, a: float = None):\n",
     "\n",
+    "    from pyiron_core import nodes\n",
     "    from pyiron_core.pyiron_workflow import Workflow\n",
-    "    import pyiron_core.pyiron_nodes as pyiron_nodes\n",
     "\n",
     "    wf = Workflow('subgraph')\n",
     "\n",
-    "    wf.Bulk = pyiron_nodes.atomistic.structure.build.Bulk(name=name, a=a) \n",
-    "    wf.M3GNet = pyiron_nodes.atomistic.engine.ase.M3GNet() \n",
-    "    wf.Static = pyiron_nodes.atomistic.calculator.ase.Static(structure=wf.Bulk, engine=wf.M3GNet) \n",
-    "    wf.GetEnergyLast = pyiron_nodes.atomistic.calculator.output.GetEnergyLast(calculator=wf.Static) \n",
+    "    wf.Bulk = nodes.atomistic.structure.build.Bulk(name=name, a=a)\n",
+    "    wf.M3GNet = nodes.atomistic.engine.ase.M3GNet()\n",
+    "    wf.Static = nodes.atomistic.calculator.ase.Static(structure=wf.Bulk, engine=wf.M3GNet)\n",
+    "    wf.GetEnergyLast = nodes.atomistic.calculator.output.GetEnergyLast(calculator=wf.Static)\n",
     "\n",
     "    return wf.GetEnergyLast.outputs.energy_last, wf.Bulk"
    ],
-   "id": "d3d5969ca6aebe24"
+   "id": "ead8d337d8f0950a"
   },
   {
    "metadata": {},
@@ -457,7 +413,7 @@
     "    output_labels = None\n",
     "output_labels"
    ],
-   "id": "51088828f07d5125"
+   "id": "30a65091f16d50b3"
   },
   {
    "cell_type": "code",
@@ -1467,133 +1423,18 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "c654bbef-29b7-41da-bf8e-dff3ffb57cb6",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:08.174716Z",
-     "start_time": "2025-05-16T23:04:08.172488Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Bulk'"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pyiron_nodes.atomistic.structure.build.Bulk('Al')._func.__qualname__"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "nodes.atomistic.structure.build.Bulk('Al')._func.__qualname__",
+   "id": "3a6209dc608c517a"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "0682af79-1fc7-4c82-ab9e-6df99aba1102",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:08.239054Z",
-     "start_time": "2025-05-16T23:04:08.234454Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'_mgr': BlockManager\n",
-      "Items: Index(['a', 'result'], dtype='object')\n",
-      "Axis 1: RangeIndex(start=0, stop=7, step=1)\n",
-      "NumpyBlock: slice(0, 2, 1), 2 x 7, dtype: float64, '_typ': 'dataframe', '_metadata': [], 'attrs': {}, '_flags': {'allows_duplicate_labels': True}}\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>result</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>3.000000</td>\n",
-       "      <td>2.528607</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>3.666667</td>\n",
-       "      <td>-3.223616</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>4.333333</td>\n",
-       "      <td>-3.567102</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>5.000000</td>\n",
-       "      <td>-2.563248</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5.666667</td>\n",
-       "      <td>-0.607272</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>6.333333</td>\n",
-       "      <td>0.184764</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>7.000000</td>\n",
-       "      <td>-0.148894</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "          a    result\n",
-       "0  3.000000  2.528607\n",
-       "1  3.666667 -3.223616\n",
-       "2  4.333333 -3.567102\n",
-       "3  5.000000 -2.563248\n",
-       "4  5.666667 -0.607272\n",
-       "5  6.333333  0.184764\n",
-       "6  7.000000 -0.148894"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "select_graph_by_name(pf, \"murn4\")\n",
     "df = pf.graph.nodes[\"IterNode\"].node.outputs.df.value\n",
@@ -1606,7 +1447,8 @@
     "df_new2 = pd.DataFrame()\n",
     "df_new2.__setstate__(state)\n",
     "df_new2"
-   ]
+   ],
+   "id": "215face7b5bc2162"
   },
   {
    "cell_type": "code",
@@ -2353,78 +2195,35 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 43,
-   "id": "c29c7d73-b5a5-4d23-835e-1a8432ce3f53",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:09.526899Z",
-     "start_time": "2025-05-16T23:04:09.519812Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "labels ['bulk__name', 'bulk__cubic']\n",
-      "inp:  bulk name\n",
-      "GraphEdge(source='va_i_subgraph__bulk__name', target='bulk', sourceHandle='x', targetHandle='name')\n",
-      "inp:  bulk cubic\n",
-      "GraphEdge(source='va_i_subgraph__bulk__cubic', target='bulk', sourceHandle='x', targetHandle='cubic')\n",
-      "labels ['volume__volume']\n",
-      "node:  bulk GraphNode(id='bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='bulk', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33af29430>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  range GraphNode(id='range', import_path='pyiron_nodes.math.Linspace', label='range', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af83d70>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  volume GraphNode(id='volume', import_path='pyiron_nodes.atomistic.structure.calc.Volume', label='volume', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33acfcf20>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  subgraph GraphNode(id='subgraph', import_path=None, label='subgraph', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af82030>, graph=Graph(id=None, label='subgraph', root_node=None, nodes=NestedDict({'bulk': GraphNode(id='bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='bulk', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af29430>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'volume': GraphNode(id='volume', import_path='pyiron_nodes.atomistic.structure.calc.Volume', label='volume', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33acfcf20>, graph=None, node_type='node', widget_type='customNode', expanded=False)}), edges=[GraphEdge(source='bulk', target='volume', sourceHandle='structure', targetHandle='structure')], graph={}), node_type='graph', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__bulk__name GraphNode(id='va_i_subgraph__bulk__name', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__bulk__name', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af2b2c0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__bulk__cubic GraphNode(id='va_i_subgraph__bulk__cubic', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__bulk__cubic', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af28a70>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_o_subgraph__volume__volume GraphNode(id='va_o_subgraph__volume__volume', import_path='pyiron_workflow.api.serial.identity', label='va_o_subgraph__volume__volume', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af829f0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "['subgraph']\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Graph(id=None, label='test', root_node=None, nodes=Nodes({'subgraph': GraphNode(id='subgraph', import_path=None, label='subgraph', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af82030>, graph=Graph(id=None, label='subgraph', root_node=None, nodes=NestedDict({'bulk': GraphNode(id='bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='bulk', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af29430>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'volume': GraphNode(id='volume', import_path='pyiron_nodes.atomistic.structure.calc.Volume', label='volume', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33acfcf20>, graph=None, node_type='node', widget_type='customNode', expanded=False)}), edges=[GraphEdge(source='bulk', target='volume', sourceHandle='structure', targetHandle='structure')], graph={}), node_type='graph', widget_type='customNode', expanded=False), 'range': GraphNode(id='range', import_path='pyiron_nodes.math.Linspace', label='range', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af83d70>, graph=None, node_type='node', widget_type='customNode', expanded=False)}), edges=[], graph={})"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "wf = pwf.Workflow(\"test\")\n",
-    "wf.bulk = pyiron_nodes.atomistic.structure.build.Bulk(\"Al\", cubic=True)\n",
-    "wf.volume = pyiron_nodes.atomistic.structure.calc.Volume(wf.bulk)\n",
+    "wf.bulk = nodes.atomistic.structure.build.Bulk(\"Al\", cubic=True)\n",
+    "wf.volume = nodes.atomistic.structure.calc.Volume(wf.bulk)\n",
     "# wf.subgraph = Group([wf.bulk, wf.volume])\n",
     "\n",
-    "wf.range = pyiron_nodes.math.Linspace(1.8, 2.2, 7)\n",
-    "# wf.executor = pyiron_nodes.executor.\n",
-    "# wf.iter = pyiron_nodes.executors.IterNode(node=wf.volume, kwarg_name=\"Bulk__name\", kwarg_list=wf.range)\n",
+    "wf.range = nodes.math.Linspace(1.8, 2.2, 7)\n",
+    "# wf.executor = nodes.executor.\n",
+    "# wf.iter = nodes.executors.IterNode(node=wf.volume, kwarg_name=\"Bulk__name\", kwarg_list=wf.range)\n",
     "\n",
     "graph = base.get_graph_from_wf(wf, [], [])\n",
     "graph_sub = base.create_group(graph, [0, 2])\n",
     "\n",
     "base.get_updated_graph(graph_sub)\n",
     "#graph_sub"
-   ]
+   ],
+   "id": "a6b0bd2f38212007"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 44,
-   "id": "b73f04e2-9bf2-41e3-881d-b6ed63b2f422",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:09.558111Z",
-     "start_time": "2025-05-16T23:04:09.556685Z"
-    }
-   },
    "outputs": [],
-   "source": [
-    "# graph.nodes[\"test\"] = base.GraphNode()"
-   ]
+   "execution_count": null,
+   "source": "# graph.nodes[\"test\"] = base.GraphNode()",
+   "id": "c6aa0858f85cd14e"
   },
   {
    "cell_type": "code",
@@ -3153,38 +2952,13 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 60,
-   "id": "4c63a09a-db8c-4a78-b51a-41fb7bc858f4",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:10.763107Z",
-     "start_time": "2025-05-16T23:04:10.757313Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 7.14 ms, sys: 4.83 ms, total: 12 ms\n",
-      "Wall time: 9.06 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<pyiron_workflow.simple_workflow.Node at 0x33afed640>"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%time\n",
-    "Al = pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")\n",
+    "Al = nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")\n",
     "\n",
     "dumps = pickle.dumps((Al, base.run_node))\n",
     "\n",
@@ -3193,69 +2967,14 @@
     "Al_p.inputs\n",
     "# Al\n",
     "pwf.Node().__setstate__(state=Al.__getstate__())"
-   ]
+   ],
+   "id": "3bb992b8201de946"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 61,
-   "id": "1f4f422d-97cf-4621-9bc3-631eabb80c88",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:10.839163Z",
-     "start_time": "2025-05-16T23:04:10.826295Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "labels ['Bulk__name', 'Bulk__a', 'Bulk__cubic', 'Linspace__x_min', 'Linspace__x_max', 'Linspace__num_points', 'IterNode__kwarg_name']\n",
-      "inp:  Bulk name\n",
-      "GraphEdge(source='va_i_subgraph__Bulk__name', target='Bulk', sourceHandle='x', targetHandle='name')\n",
-      "inp:  Bulk a\n",
-      "GraphEdge(source='va_i_subgraph__Bulk__a', target='Bulk', sourceHandle='x', targetHandle='a')\n",
-      "inp:  Bulk cubic\n",
-      "GraphEdge(source='va_i_subgraph__Bulk__cubic', target='Bulk', sourceHandle='x', targetHandle='cubic')\n",
-      "inp:  Linspace x_min\n",
-      "GraphEdge(source='va_i_subgraph__Linspace__x_min', target='Linspace', sourceHandle='x', targetHandle='x_min')\n",
-      "inp:  Linspace x_max\n",
-      "GraphEdge(source='va_i_subgraph__Linspace__x_max', target='Linspace', sourceHandle='x', targetHandle='x_max')\n",
-      "inp:  Linspace num_points\n",
-      "GraphEdge(source='va_i_subgraph__Linspace__num_points', target='Linspace', sourceHandle='x', targetHandle='num_points')\n",
-      "inp:  IterNode kwarg_name\n",
-      "GraphEdge(source='va_i_subgraph__IterNode__kwarg_name', target='IterNode', sourceHandle='x', targetHandle='kwarg_name')\n",
-      "labels ['IterNode__df']\n",
-      "node:  Bulk GraphNode(id='Bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='Bulk', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33aecc2f0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  Volume GraphNode(id='Volume', import_path='pyiron_nodes.atomistic.structure.calc.Volume', label='Volume', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33af911f0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  ThreadPoolExecutor GraphNode(id='ThreadPoolExecutor', import_path='pyiron_nodes.executors.ThreadPoolExecutor', label='ThreadPoolExecutor', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33afed700>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  IterNode GraphNode(id='IterNode', import_path='pyiron_nodes.executors.IterNode', label='IterNode', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33afef860>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  SingleNodeExecutor GraphNode(id='SingleNodeExecutor', import_path='pyiron_nodes.executors.SingleNodeExecutor', label='SingleNodeExecutor', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afee270>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  Linspace GraphNode(id='Linspace', import_path='pyiron_nodes.math.Linspace', label='Linspace', parent_id='subgraph', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33afee210>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  subgraph GraphNode(id='subgraph', import_path=None, label='subgraph', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afeeae0>, graph=Graph(id=None, label='subgraph', root_node=None, nodes=NestedDict({'Bulk': GraphNode(id='Bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='Bulk', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33aecc2f0>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'ThreadPoolExecutor': GraphNode(id='ThreadPoolExecutor', import_path='pyiron_nodes.executors.ThreadPoolExecutor', label='ThreadPoolExecutor', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afed700>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'Linspace': GraphNode(id='Linspace', import_path='pyiron_nodes.math.Linspace', label='Linspace', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afee210>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'Volume': GraphNode(id='Volume', import_path='pyiron_nodes.atomistic.structure.calc.Volume', label='Volume', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af911f0>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'IterNode': GraphNode(id='IterNode', import_path='pyiron_nodes.executors.IterNode', label='IterNode', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afef860>, graph=None, node_type='node', widget_type='customNode', expanded=False)}), edges=[GraphEdge(source='Bulk', target='Volume', sourceHandle='structure', targetHandle='structure'), GraphEdge(source='Volume', target='IterNode', sourceHandle='volume', targetHandle='node'), GraphEdge(source='ThreadPoolExecutor', target='IterNode', sourceHandle='Executor', targetHandle='Executor'), GraphEdge(source='Linspace', target='IterNode', sourceHandle='linspace', targetHandle='kwarg_list')], graph={}), node_type='graph', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Bulk__name GraphNode(id='va_i_subgraph__Bulk__name', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Bulk__name', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afeec90>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Bulk__a GraphNode(id='va_i_subgraph__Bulk__a', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Bulk__a', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33aece030>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Bulk__cubic GraphNode(id='va_i_subgraph__Bulk__cubic', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Bulk__cubic', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33af53560>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Linspace__x_min GraphNode(id='va_i_subgraph__Linspace__x_min', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Linspace__x_min', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afef5c0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Linspace__x_max GraphNode(id='va_i_subgraph__Linspace__x_max', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Linspace__x_max', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afef800>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__Linspace__num_points GraphNode(id='va_i_subgraph__Linspace__num_points', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__Linspace__num_points', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afefa40>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_i_subgraph__IterNode__kwarg_name GraphNode(id='va_i_subgraph__IterNode__kwarg_name', import_path='pyiron_workflow.api.serial.identity', label='va_i_subgraph__IterNode__kwarg_name', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afefbc0>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "node:  va_o_subgraph__IterNode__df GraphNode(id='va_o_subgraph__IterNode__df', import_path='pyiron_workflow.api.serial.identity', label='va_o_subgraph__IterNode__df', parent_id='subgraph', level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33afefd70>, graph=None, node_type='node', widget_type='customNode', expanded=False)\n",
-      "['subgraph']\n",
-      "<class 'pyiron_workflow.graph.base.GraphNode'>\n",
-      "NODE:  Bulk\n",
-      "<class 'pyiron_workflow.graph.base.GraphNode'>\n",
-      "NODE:  ThreadPoolExecutor\n",
-      "<class 'pyiron_workflow.graph.base.GraphNode'>\n",
-      "NODE:  Linspace\n",
-      "<class 'pyiron_workflow.graph.base.GraphNode'>\n",
-      "NODE:  Volume\n",
-      "<class 'pyiron_workflow.graph.base.GraphNode'>\n",
-      "NODE:  IterNode\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "graph = base._load_graph(\"executor3\", workflow_dir=json_file_location)\n",
     "\n",
@@ -3276,7 +2995,8 @@
     "    \n",
     "    g = base.GraphNode().__setstate__(node.__getstate__())\n",
     "    print('NODE: ', g.label)"
-   ]
+   ],
+   "id": "a4d5bbb5233af6df"
   },
   {
    "cell_type": "code",
@@ -4734,224 +4454,40 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 88,
-   "id": "d4e496cb-e96c-4b0f-a095-4e523a20200a",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:13.573451Z",
-     "start_time": "2025-05-16T23:04:13.569707Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Al: [0. 0. 0.]\n",
-       "tags: \n",
-       "    indices: [0]\n",
-       "pbc: [ True  True  True]\n",
-       "cell: \n",
-       "Cell([[0.0, 2.025, 2.025], [2.025, 0.0, 2.025], [2.025, 2.025, 0.0]])"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pyiron_nodes.atomistic.structure.build.Bulk()._func(name='Al')"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "nodes.atomistic.structure.build.Bulk()._func(name='Al')",
+   "id": "d4eb709a4ca5c220"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 89,
-   "id": "c634ccdf-b015-40e0-892b-d41949957810",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:13.639270Z",
-     "start_time": "2025-05-16T23:04:13.635966Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>label</th>\n",
-       "      <th>type</th>\n",
-       "      <th>default</th>\n",
-       "      <th>ready</th>\n",
-       "      <th>value</th>\n",
-       "      <th>node</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>name</td>\n",
-       "      <td>str</td>\n",
-       "      <td>NotData</td>\n",
-       "      <td>True</td>\n",
-       "      <td>Al</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>crystalstructure</td>\n",
-       "      <td>str</td>\n",
-       "      <td>None</td>\n",
-       "      <td>True</td>\n",
-       "      <td>None</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>a</td>\n",
-       "      <td>int</td>\n",
-       "      <td>None</td>\n",
-       "      <td>True</td>\n",
-       "      <td>None</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>c</td>\n",
-       "      <td>int</td>\n",
-       "      <td>None</td>\n",
-       "      <td>True</td>\n",
-       "      <td>None</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>c_over_a</td>\n",
-       "      <td>int</td>\n",
-       "      <td>None</td>\n",
-       "      <td>True</td>\n",
-       "      <td>None</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>u</td>\n",
-       "      <td>int</td>\n",
-       "      <td>None</td>\n",
-       "      <td>True</td>\n",
-       "      <td>None</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>orthorhombic</td>\n",
-       "      <td>bool</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>cubic</td>\n",
-       "      <td>bool</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "{'label': ['name', 'crystalstructure', 'a', 'c', 'c_over_a', 'u', 'orthorhombic', 'cubic'], 'type': ['str', 'str', 'int', 'int', 'int', 'int', 'bool', 'bool'], 'default': ['NotData', None, None, None, None, None, False, False], 'ready': [True, True, True, True, True, True, True, True], 'value': ['Al', None, None, None, None, None, False, False], 'node': [<pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>, <pyiron_workflow.simple_workflow.Node object at 0x33a824560>]}"
-      ]
-     },
-     "execution_count": 89,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "bulk = pyiron_nodes.atomistic.structure.build.Bulk()\n",
+    "bulk = nodes.atomistic.structure.build.Bulk()\n",
     "bulk.inputs[\"name\"] = \"Al\"\n",
     "bulk.inputs"
-   ]
+   ],
+   "id": "b9063ad54140f31e"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 90,
-   "id": "f9b5648c-5f4b-4586-af0a-65cd47a2ad08",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:13.697225Z",
-     "start_time": "2025-05-16T23:04:13.694313Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Al: [0. 0. 0.]\n",
-       "tags: \n",
-       "    indices: [0]\n",
-       "pbc: [ True  True  True]\n",
-       "cell: \n",
-       "Cell([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]])"
-      ]
-     },
-     "execution_count": 90,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pyiron_nodes.atomistic.structure.build.Bulk()('Al', a=2)"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "nodes.atomistic.structure.build.Bulk()('Al', a=2)",
+   "id": "c3a011c4fc32601f"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 91,
-   "id": "7f969cb0-9193-4718-b9f3-561581444380",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:13.831641Z",
-     "start_time": "2025-05-16T23:04:13.829518Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Volume', 'Bulk']"
-      ]
-     },
-     "execution_count": 91,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "list(set(['Volume', 'Bulk', 'Volume']))"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "list(set(['Volume', 'Bulk', 'Volume']))",
+   "id": "3916b7febd1c3c2d"
   },
   {
    "cell_type": "code",
@@ -5244,19 +4780,19 @@
     "@pwf.as_macro_node(\"out\")\n",
     "def subgraph(Bulk__name: str = \"Al\"):\n",
     "\n",
+    "    from pyiron_core import nodes\n",
     "    from pyiron_core.pyiron_workflow import Workflow\n",
-    "    import pyiron_core.pyiron_nodes as pyiron_nodes\n",
     "\n",
     "    wf = Workflow('subgraph')\n",
     "\n",
-    "    wf.Bulk = pyiron_nodes.atomistic.structure.build.Bulk(name=Bulk__name)\n",
-    "    wf.Volume = pyiron_nodes.atomistic.structure.calc.Volume(structure=wf.Bulk)\n",
+    "    wf.Bulk = nodes.atomistic.structure.build.Bulk(name=Bulk__name)\n",
+    "    wf.Volume = nodes.atomistic.structure.calc.Volume(structure=wf.Bulk)\n",
     "\n",
     "    return wf.Volume\n",
     "\n",
     "subgraph()(Bulk__name=\"Al\")"
    ],
-   "id": "954bd0b782071178"
+   "id": "ecefaf2faba857d7"
   },
   {
    "metadata": {},
@@ -5264,7 +4800,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "subgraph().node_type",
-   "id": "a5e454980c0b4fa9"
+   "id": "a41c634f50954849"
   },
   {
    "cell_type": "code",
@@ -5471,22 +5007,22 @@
     "cell_size = 3\n",
     "solid_fraction = 0\n",
     "\n",
-    "wf.CubicBulkCell = pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size) \n",
-    "wf.Potential = pyiron_nodes.atomistic.engine.lammps.Potential(structure=wf.CubicBulkCell) \n",
+    "wf.CubicBulkCell = nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size)\n",
+    "wf.Potential = nodes.atomistic.engine.lammps.Potential(structure=wf.CubicBulkCell)\n",
     "\n",
-    "wf.Tolerance = pyiron_nodes.atomistic.property.calphy.Tolerance(solid_fraction=solid_fraction) \n",
-    "wf.InputClass = pyiron_nodes.atomistic.property.calphy.InputClass() \n",
-    "wf.InputClass_1 = pyiron_nodes.atomistic.property.calphy.InputClass(tolerance=wf.Tolerance) \n",
-    "wf.SolidFreeEnergyWithTemperature = pyiron_nodes.atomistic.property.calphy.SolidFreeEnergyWithTemperature(structure=wf.CubicBulkCell, potential=wf.Potential, inp=wf.InputClass_1, store=False) \n",
-    "wf.LiquidFreeEnergyWithTemperature = pyiron_nodes.atomistic.property.calphy.LiquidFreeEnergyWithTemperature(potential=wf.Potential, structure=wf.CubicBulkCell, inp=wf.InputClass, store=False) \n",
-    "wf.CalculatePhaseTransformationTemperature = pyiron_nodes.atomistic.property.calphy.CalculatePhaseTransformationTemperature(t1=wf.SolidFreeEnergyWithTemperature.outputs.t, \n",
+    "wf.Tolerance = nodes.atomistic.property.calphy.Tolerance(solid_fraction=solid_fraction)\n",
+    "wf.InputClass = nodes.atomistic.property.calphy.InputClass()\n",
+    "wf.InputClass_1 = nodes.atomistic.property.calphy.InputClass(tolerance=wf.Tolerance)\n",
+    "wf.SolidFreeEnergyWithTemperature = nodes.atomistic.property.calphy.SolidFreeEnergyWithTemperature(structure=wf.CubicBulkCell, potential=wf.Potential, inp=wf.InputClass_1, store=False)\n",
+    "wf.LiquidFreeEnergyWithTemperature = nodes.atomistic.property.calphy.LiquidFreeEnergyWithTemperature(potential=wf.Potential, structure=wf.CubicBulkCell, inp=wf.InputClass, store=False)\n",
+    "wf.CalculatePhaseTransformationTemperature = nodes.atomistic.property.calphy.CalculatePhaseTransformationTemperature(t1=wf.SolidFreeEnergyWithTemperature.outputs.t,\n",
     "                                                                                                                            f1=wf.SolidFreeEnergyWithTemperature.outputs.f, \n",
     "                                                                                                                            t2=wf.LiquidFreeEnergyWithTemperature.outputs.t, \n",
     "                                                                                                                            f2=wf.LiquidFreeEnergyWithTemperature.outputs.f) \n",
     "\n",
     "wf.CalculatePhaseTransformationTemperature.pull()"
    ],
-   "id": "79d03e6ebae65b8e"
+   "id": "fccfc68291e4db82"
   },
   {
    "metadata": {},
@@ -5503,7 +5039,7 @@
     "\n",
     "base.pull_node(base.get_updated_graph(graph), \"LiquidFreeEnergyWithTemperature\")"
    ],
-   "id": "5b068e9e5d6354eb"
+   "id": "e46431340e34ea1"
   },
   {
    "cell_type": "markdown",
@@ -5530,25 +5066,25 @@
     "@pwf.as_macro_node(\"transition_temperature\")\n",
     "def calphy2(element: str, cell_size: int = 1, solid_fraction: float = 0.7):\n",
     "\n",
+    "    from pyiron_core import nodes\n",
     "    from pyiron_core.pyiron_workflow import Workflow\n",
-    "    import pyiron_core.pyiron_nodes as pyiron_nodes\n",
     "\n",
     "    wf = Workflow('calphy2')\n",
     "\n",
-    "    wf.CubicBulkCell = pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size) \n",
-    "    wf.Tolerance = pyiron_nodes.atomistic.property.calphy.Tolerance(solid_fraction=solid_fraction) \n",
-    "    wf.InputClass = pyiron_nodes.atomistic.property.calphy.InputClass() \n",
-    "    wf.Potential = pyiron_nodes.atomistic.engine.lammps.Potential(structure=wf.CubicBulkCell) \n",
-    "    wf.InputClass_1 = pyiron_nodes.atomistic.property.calphy.InputClass(tolerance=wf.Tolerance) \n",
-    "    wf.LiquidFreeEnergyWithTemperature = pyiron_nodes.atomistic.property.calphy.LiquidFreeEnergyWithTemperature(potential=wf.Potential, structure=wf.CubicBulkCell, inp=wf.InputClass) \n",
-    "    wf.SolidFreeEnergyWithTemperature = pyiron_nodes.atomistic.property.calphy.SolidFreeEnergyWithTemperature(structure=wf.CubicBulkCell, potential=wf.Potential, inp=wf.InputClass_1) \n",
-    "    wf.CalculatePhaseTransformationTemperature = pyiron_nodes.atomistic.property.calphy.CalculatePhaseTransformationTemperature(t1=wf.SolidFreeEnergyWithTemperature.outputs.t, f1=wf.SolidFreeEnergyWithTemperature.outputs.f, t2=wf.LiquidFreeEnergyWithTemperature.outputs.t, f2=wf.LiquidFreeEnergyWithTemperature.outputs.f) \n",
+    "    wf.CubicBulkCell = nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size)\n",
+    "    wf.Tolerance = nodes.atomistic.property.calphy.Tolerance(solid_fraction=solid_fraction)\n",
+    "    wf.InputClass = nodes.atomistic.property.calphy.InputClass()\n",
+    "    wf.Potential = nodes.atomistic.engine.lammps.Potential(structure=wf.CubicBulkCell)\n",
+    "    wf.InputClass_1 = nodes.atomistic.property.calphy.InputClass(tolerance=wf.Tolerance)\n",
+    "    wf.LiquidFreeEnergyWithTemperature = nodes.atomistic.property.calphy.LiquidFreeEnergyWithTemperature(potential=wf.Potential, structure=wf.CubicBulkCell, inp=wf.InputClass)\n",
+    "    wf.SolidFreeEnergyWithTemperature = nodes.atomistic.property.calphy.SolidFreeEnergyWithTemperature(structure=wf.CubicBulkCell, potential=wf.Potential, inp=wf.InputClass_1)\n",
+    "    wf.CalculatePhaseTransformationTemperature = nodes.atomistic.property.calphy.CalculatePhaseTransformationTemperature(t1=wf.SolidFreeEnergyWithTemperature.outputs.t, f1=wf.SolidFreeEnergyWithTemperature.outputs.f, t2=wf.LiquidFreeEnergyWithTemperature.outputs.t, f2=wf.LiquidFreeEnergyWithTemperature.outputs.f)\n",
     "\n",
     "    return wf.CalculatePhaseTransformationTemperature# .outputs.transition_temp #, wf.CalculatePhaseTransformationTemperature.outputs.plot\n",
     "\n",
     "    "
    ],
-   "id": "8c87c62f8343810d"
+   "id": "89003ff5cf41e0a4"
   },
   {
    "cell_type": "markdown",
@@ -5635,17 +5171,17 @@
     "@pwf.as_macro_node(\"transition_temperature\")\n",
     "def calphy2(element: str, cell_size: int = 1, solid_fraction: float = 0.7):\n",
     "\n",
+    "    from pyiron_core import nodes\n",
     "    from pyiron_core.pyiron_workflow import Workflow\n",
-    "    import pyiron_core.pyiron_nodes as pyiron_nodes\n",
     "\n",
     "    wf = Workflow('calphy2')\n",
     "\n",
     "    # wf.CubicBulkCell = pyiron_nodes.atomistic.structure.build.Bulk(\"Al\") # CubicBulkCell(element=element, cell_size=cell_size) \n",
-    "    wf.CubicBulkCell = pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size)\n",
+    "    wf.CubicBulkCell = nodes.atomistic.structure.build.CubicBulkCell(element=element, cell_size=cell_size)\n",
     "\n",
     "    return wf.CubicBulkCell"
    ],
-   "id": "271cb65c1239fb2b"
+   "id": "951223034199a488"
   },
   {
    "metadata": {},
@@ -5654,240 +5190,16 @@
    "execution_count": null,
    "source": [
     "graph = base.Graph()\n",
-    "graph += pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")\n",
+    "graph += nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")\n",
     "graph.nodes"
    ],
-   "id": "998fca1b73f384eb"
+   "id": "97441b669c659e84"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 110,
-   "id": "a1c7adc6-7d73-4c4c-afef-d3d4df82424f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:40.975475Z",
-     "start_time": "2025-05-16T23:04:40.950227Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Adding macro node CubicBulkCell\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>import_path</th>\n",
-       "      <th>label</th>\n",
-       "      <th>parent_id</th>\n",
-       "      <th>level</th>\n",
-       "      <th>node</th>\n",
-       "      <th>graph</th>\n",
-       "      <th>node_type</th>\n",
-       "      <th>widget_type</th>\n",
-       "      <th>expanded</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>pyiron_nodes.atomistic.structure.build.CubicBu...</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>Graph(id='CubicBulkCell', label='CubicBulkCell...</td>\n",
-       "      <td>graph</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>va_i_CubicBulkCell__vacancy_index</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_i_CubicBulkCell__vacancy_index</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>va_i_calphy2__element</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_i_calphy2__element</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>va_i_calphy2__cell_size</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_i_calphy2__cell_size</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>va_i_CubicBulkCell__element</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_i_CubicBulkCell__element</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>va_i_CubicBulkCell__cell_size</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_i_CubicBulkCell__cell_size</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>bulk</td>\n",
-       "      <td>pyiron_nodes.atomistic.structure.build.Bulk</td>\n",
-       "      <td>bulk</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>repeat</td>\n",
-       "      <td>pyiron_nodes.atomistic.structure.transform.Repeat</td>\n",
-       "      <td>repeat</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>vacancy</td>\n",
-       "      <td>pyiron_nodes.atomistic.structure.transform.Cre...</td>\n",
-       "      <td>vacancy</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>va_o_CubicBulkCell__structure</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_o_CubicBulkCell__structure</td>\n",
-       "      <td>CubicBulkCell</td>\n",
-       "      <td>1</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>va_o_calphy2__transition_temperature</td>\n",
-       "      <td>pyiron_workflow.api.serial.identity</td>\n",
-       "      <td>va_o_calphy2__transition_temperature</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0</td>\n",
-       "      <td>&lt;pyiron_workflow.simple_workflow.Node object a...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>node</td>\n",
-       "      <td>customNode</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "NestedDict([('CubicBulkCell',\n",
-       "             GraphNode(id='CubicBulkCell', import_path='pyiron_nodes.atomistic.structure.build.CubicBulkCell', label='CubicBulkCell', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35f080>, graph=Graph(id='CubicBulkCell', label='CubicBulkCell', root_node=None, nodes=NestedDict({'va_i_CubicBulkCell__element': GraphNode(id='va_i_CubicBulkCell__element', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__element', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35dee0>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'va_i_CubicBulkCell__cell_size': GraphNode(id='va_i_CubicBulkCell__cell_size', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__cell_size', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35da00>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'va_i_CubicBulkCell__vacancy_index': GraphNode(id='va_i_CubicBulkCell__vacancy_index', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__vacancy_index', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x34242f620>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'bulk': GraphNode(id='bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='bulk', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35eb70>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'repeat': GraphNode(id='repeat', import_path='pyiron_nodes.atomistic.structure.transform.Repeat', label='repeat', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35ec30>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'vacancy': GraphNode(id='vacancy', import_path='pyiron_nodes.atomistic.structure.transform.CreateVacancy', label='vacancy', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35f260>, graph=None, node_type='node', widget_type='customNode', expanded=False), 'va_o_CubicBulkCell__structure': GraphNode(id='va_o_CubicBulkCell__structure', import_path='pyiron_workflow.api.serial.identity', label='va_o_CubicBulkCell__structure', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35f4d0>, graph=None, node_type='node', widget_type='customNode', expanded=False)}), edges=[GraphEdge(source='va_i_CubicBulkCell__element', target='bulk', sourceHandle='x', targetHandle='name'), GraphEdge(source='va_i_CubicBulkCell__cell_size', target='repeat', sourceHandle='x', targetHandle='repeat_scalar'), GraphEdge(source='va_i_CubicBulkCell__vacancy_index', target='vacancy', sourceHandle='x', targetHandle='index'), GraphEdge(source='bulk', target='repeat', sourceHandle='structure', targetHandle='structure'), GraphEdge(source='repeat', target='vacancy', sourceHandle='structure', targetHandle='structure'), GraphEdge(source='vacancy', target='va_o_CubicBulkCell__structure', sourceHandle='structure', targetHandle='x')], graph={}), node_type='graph', widget_type='customNode', expanded=True)),\n",
-       "            ('va_i_CubicBulkCell__vacancy_index',\n",
-       "             GraphNode(id='va_i_CubicBulkCell__vacancy_index', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__vacancy_index', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x34242f620>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_i_calphy2__element',\n",
-       "             GraphNode(id='va_i_calphy2__element', import_path='pyiron_workflow.api.serial.identity', label='va_i_calphy2__element', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35e870>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_i_calphy2__cell_size',\n",
-       "             GraphNode(id='va_i_calphy2__cell_size', import_path='pyiron_workflow.api.serial.identity', label='va_i_calphy2__cell_size', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35c2f0>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_i_CubicBulkCell__element',\n",
-       "             GraphNode(id='va_i_CubicBulkCell__element', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__element', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35dee0>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_i_CubicBulkCell__cell_size',\n",
-       "             GraphNode(id='va_i_CubicBulkCell__cell_size', import_path='pyiron_workflow.api.serial.identity', label='va_i_CubicBulkCell__cell_size', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35da00>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('bulk',\n",
-       "             GraphNode(id='bulk', import_path='pyiron_nodes.atomistic.structure.build.Bulk', label='bulk', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35eb70>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('repeat',\n",
-       "             GraphNode(id='repeat', import_path='pyiron_nodes.atomistic.structure.transform.Repeat', label='repeat', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35ec30>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('vacancy',\n",
-       "             GraphNode(id='vacancy', import_path='pyiron_nodes.atomistic.structure.transform.CreateVacancy', label='vacancy', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35f260>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_o_CubicBulkCell__structure',\n",
-       "             GraphNode(id='va_o_CubicBulkCell__structure', import_path='pyiron_workflow.api.serial.identity', label='va_o_CubicBulkCell__structure', parent_id='CubicBulkCell', level=1, node=<pyiron_workflow.simple_workflow.Node object at 0x33e35f4d0>, graph=None, node_type='node', widget_type='customNode', expanded=False)),\n",
-       "            ('va_o_calphy2__transition_temperature',\n",
-       "             GraphNode(id='va_o_calphy2__transition_temperature', import_path='pyiron_workflow.api.serial.identity', label='va_o_calphy2__transition_temperature', parent_id=None, level=0, node=<pyiron_workflow.simple_workflow.Node object at 0x33bf98980>, graph=None, node_type='node', widget_type='customNode', expanded=False))])"
-      ]
-     },
-     "execution_count": 110,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "n = calphy2(element=\"Al\")\n",
     "graph = base.get_graph_from_macro_node(n)\n",
@@ -5895,24 +5207,20 @@
     "# base.GuiGraph(base.get_graph_from_macro_node(n))\n",
     "# base.get_graph_from_macro_node(n).nodes[\"CubicBulkCell\"].node.run()\n",
     "graph.nodes"
-   ]
+   ],
+   "id": "7a165d4785bae102"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 111,
-   "id": "0871dc72-bbb2-415d-948a-07e567b46692",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:43.209292Z",
-     "start_time": "2025-05-16T23:04:43.205520Z"
-    }
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "@pwf.as_macro_node(\"structure\")\n",
     "def CubicBulkCell(\n",
     "    element: str, cell_size: int = 1, vacancy_index: Optional[int] = None\n",
     "):\n",
+    "\n",
     "    from pyiron_core.pyiron_nodes.atomistic.structure.build import Bulk\n",
     "    from pyiron_core.pyiron_nodes.atomistic.structure.transform import (\n",
     "        CreateVacancy,\n",
@@ -5927,103 +5235,37 @@
     "\n",
     "    wf.vacancy = CreateVacancy(structure=wf.repeat, index=vacancy_index)\n",
     "    return wf.vacancy"
-   ]
+   ],
+   "id": "c74dfebd4abdbcb4"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 112,
-   "id": "a9597fdd-42ba-47cf-9a5f-b43b591e8ddf",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:43.631228Z",
-     "start_time": "2025-05-16T23:04:43.616814Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pyiron_log:Not supported parameter used!\n",
-      "DEBUG:pyiron_log:Not supported parameter used!\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Al: [0. 0. 0.]\n",
-       "Al: [0.    2.025 2.025]\n",
-       "Al: [2.025 0.    2.025]\n",
-       "Al: [2.025 2.025 0.   ]\n",
-       "tags: \n",
-       "    indices: [0 0 0 0]\n",
-       "pbc: [ True  True  True]\n",
-       "cell: \n",
-       "Cell([4.05, 4.05, 4.05])"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "CubicBulkCell(\"Al\").run()"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "CubicBulkCell(\"Al\").run()",
+   "id": "626ff19d1e4ad669"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 113,
-   "id": "9caa1440-021d-4b7c-9969-04bb5d8fd8ba",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:43.695664Z",
-     "start_time": "2025-05-16T23:04:43.691930Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<pyiron_workflow.simple_workflow.Node at 0x34242cef0>"
-      ]
-     },
-     "execution_count": 113,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pyiron_nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")"
-   ]
+   "outputs": [],
+   "execution_count": null,
+   "source": "nodes.atomistic.structure.build.CubicBulkCell(element=\"Al\")",
+   "id": "b63e162107b1a67f"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 114,
-   "id": "cd50efb4-1c88-4f5f-a0e4-d57df4965f99",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:43.978583Z",
-     "start_time": "2025-05-16T23:04:43.782445Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[4, 6, 8]\n",
-      "CPU times: user 54.5 ms, sys: 53.6 ms, total: 108 ms\n",
-      "Wall time: 229 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%time\n",
     "with executorlib.SingleNodeExecutor(max_workers=4, block_allocation=True) as exe:\n",
     "    future_lst = [exe.submit(sum, [i, i]) for i in range(2, 5)]\n",
     "    print([f.result() for f in future_lst])"
-   ]
+   ],
+   "id": "5ab6664763ec0191"
   },
   {
    "cell_type": "code",
@@ -6091,157 +5333,46 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 117,
-   "id": "b95be360-2e2e-46ce-a93a-a1c08c73b851",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:45.401202Z",
-     "start_time": "2025-05-16T23:04:44.333044Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Al: [0. 0. 0.]\n",
-      "tags: \n",
-      "    indices: [0]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([[0.0, 2.025, 2.025], [2.025, 0.0, 2.025], [2.025, 2.025, 0.0]])\n",
-      ", Fe: [0. 0. 0.]\n",
-      "tags: \n",
-      "    indices: [0]\n",
-      "    spin: [2.3]\n",
-      "    initial_magmoms: [2.3]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([[-1.435, 1.435, 1.435], [1.435, -1.435, 1.435], [1.435, 1.435, -1.435]])\n",
-      ", Ni: [0. 0. 0.]\n",
-      "tags: \n",
-      "    indices: [0]\n",
-      "    spin: [0.6]\n",
-      "    initial_magmoms: [0.6]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([[0.0, 1.76, 1.76], [1.76, 0.0, 1.76], [1.76, 1.76, 0.0]])\n",
-      ", Zn: [0. 0. 0.]\n",
-      "Zn: [4.92198874e-17 1.53575172e+00 2.46848000e+00]\n",
-      "tags: \n",
-      "    indices: [0 0]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([[2.66, 0.0, 0.0], [-1.33, 2.303627574066607, 0.0], [0.0, 0.0, 4.936960000000001]])\n",
-      "]\n",
-      "CPU times: user 35.9 ms, sys: 24.4 ms, total: 60.3 ms\n",
-      "Wall time: 1.68 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%time\n",
     "with executorlib.SingleNodeExecutor(max_workers=1, block_allocation=True) as exe:\n",
-    "    future_lst = [exe.submit(pyiron_nodes.atomistic.structure.build.Bulk()._func, n) for n in [\"Al\", \"Fe\", \"Ni\", \"Zn\"]]\n",
+    "    future_lst = [exe.submit(nodes.atomistic.structure.build.Bulk()._func, n) for n in [\"Al\", \"Fe\", \"Ni\", \"Zn\"]]\n",
     "    print([f.result() for f in future_lst])"
-   ]
+   ],
+   "id": "2003a640ec4b80bf"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 118,
-   "id": "532afe80-f1a3-4d82-8bcc-2324e3b99ef1",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:45.418897Z",
-     "start_time": "2025-05-16T23:04:45.415464Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Aluminum'"
-      ]
-     },
-     "execution_count": 118,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "Al = pyiron_nodes.atomistic.structure.build.Bulk()._func('Al')\n",
+    "Al = nodes.atomistic.structure.build.Bulk()._func('Al')\n",
     "Al.species[0].name"
-   ]
+   ],
+   "id": "8494bc4c5ff828a0"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 119,
-   "id": "c0083e59-4db2-4183-86c3-86fcef316418",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:45.447267Z",
-     "start_time": "2025-05-16T23:04:45.442745Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Al\n",
-      "Fe\n",
-      "CPU times: user 1.63 ms, sys: 816 μs, total: 2.45 ms\n",
-      "Wall time: 1.8 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%time\n",
     "for n in [\"Al\", \"Fe\"]:\n",
-    "    print(pyiron_nodes.atomistic.structure.build.Bulk(n).run())"
-   ]
+    "    print(nodes.atomistic.structure.build.Bulk(n).run())"
+   ],
+   "id": "67d0b8f13a8ad212"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 120,
-   "id": "20fd887b-2109-427d-bdab-b6f4379a3bca",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:45.483417Z",
-     "start_time": "2025-05-16T23:04:45.478130Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "out:  Al\n",
-      "Al: [0. 0. 0.]\n",
-      "Al: [0.    2.025 2.025]\n",
-      "Al: [2.025 0.    2.025]\n",
-      "Al: [2.025 2.025 0.   ]\n",
-      "tags: \n",
-      "    indices: [0 0 0 0]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([4.05, 4.05, 4.05])\n",
-      "\n",
-      "out:  Fe\n",
-      "Fe: [0. 0. 0.]\n",
-      "Fe: [1.435 1.435 1.435]\n",
-      "tags: \n",
-      "    indices: [0 0]\n",
-      "    spin: [2.3 2.3]\n",
-      "    initial_magmoms: [2.3 2.3]\n",
-      "pbc: [ True  True  True]\n",
-      "cell: \n",
-      "Cell([2.87, 2.87, 2.87])\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "elements = ['Al', 'Fe']\n",
     "\n",
@@ -6249,26 +5380,21 @@
     "# We can use a with statement to ensure threads are cleaned up promptly\n",
     "with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:\n",
     "    # Start the load operations and mark each future with its URL\n",
-    "    futures = {executor.submit(pyiron_nodes.atomistic.structure.build.Bulk()._func, el, **{'cubic': True}): el for el in elements}\n",
+    "    futures = {executor.submit(nodes.atomistic.structure.build.Bulk()._func, el, **{'cubic': True}): el for el in elements}\n",
     "    for future in concurrent.futures.as_completed(futures):\n",
     "        out = futures[future]\n",
     "        print(\"out: \", out)\n",
     "\n",
     "        data = future.result()\n",
     "        print(data.__repr__())"
-   ]
+   ],
+   "id": "80d979fb1255860c"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 121,
-   "id": "28ba5f31-8df6-4da3-a618-d3065c7695cf",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:45.519279Z",
-     "start_time": "2025-05-16T23:04:45.516637Z"
-    }
-   },
    "outputs": [],
+   "execution_count": null,
    "source": [
     "@pwf.as_function_node\n",
     "def IterNode(node: pwf.Node, kwarg_name: str, kwarg_list: list, max_workers: int=1, executor=None):\n",
@@ -6290,68 +5416,27 @@
     "            \n",
     "    return out_dict\n",
     "    "
-   ]
+   ],
+   "id": "73021549702739c4"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 122,
-   "id": "021cc7ef-497a-460d-ba05-023576693b49",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:46.482440Z",
-     "start_time": "2025-05-16T23:04:45.539113Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "copy node:  Bulk 71d3045ad08e22c2646746e6074957270f043ff8bff8fb5a12fd3ac1dad2cab0\n",
-      "CPU times: user 276 ms, sys: 78.6 ms, total: 355 ms\n",
-      "Wall time: 1.6 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'Al': 'Aluminum', 'Fe': 'Iron'}"
-      ]
-     },
-     "execution_count": 122,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%time\n",
     "elements = ['Al', 'Fe']\n",
     "\n",
-    "IterNode(pyiron_nodes.atomistic.structure.build.Bulk(), \"name\", elements, max_workers=2).run()"
-   ]
+    "IterNode(nodes.atomistic.structure.build.Bulk(), \"name\", elements, max_workers=2).run()"
+   ],
+   "id": "456639a345db788e"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": 123,
-   "id": "7a5caa72-0d1b-4365-85ef-617c37780129",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:46.499762Z",
-     "start_time": "2025-05-16T23:04:46.497168Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([3, 1, 8])"
-      ]
-     },
-     "execution_count": 123,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "# Define the matrix mat and the index array ind1\n",
     "mat = np.array([[0, 1, 2],\n",
@@ -6364,57 +5449,28 @@
     "v = mat[ind1, np.arange(len(ind1))]\n",
     "\n",
     "v  # Output: [3, 1, 8]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 124,
-   "id": "72419698-9941-49bc-a82d-33e24aaa086c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:46.524525Z",
-     "start_time": "2025-05-16T23:04:46.522173Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "n = pyiron_nodes.atomistic.structure.build.Bulk(\"Al\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 125,
-   "id": "3b67d2e9-2aa3-4d65-beef-9bee931e98e2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-05-16T23:04:46.561385Z",
-     "start_time": "2025-05-16T23:04:46.559276Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'name': 'Al',\n",
-       " 'crystalstructure': None,\n",
-       " 'a': 2.1,\n",
-       " 'c': None,\n",
-       " 'c_over_a': None,\n",
-       " 'u': None,\n",
-       " 'orthorhombic': False,\n",
-       " 'cubic': False}"
-      ]
-     },
-     "execution_count": 125,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
    ],
+   "id": "91e3f62e214ea97d"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "n = nodes.atomistic.structure.build.Bulk(\"Al\")",
+   "id": "2b7b320296d5eb8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "kwargs = n.kwargs\n",
     "kwargs.update({\"a\": 2.1})\n",
     "kwargs"
-   ]
+   ],
+   "id": "bdd1f691a152e930"
   },
   {
    "metadata": {},

--- a/notebooks/running/demo.ipynb
+++ b/notebooks/running/demo.ipynb
@@ -190,12 +190,12 @@
    "outputs": [],
    "execution_count": null,
    "source": [
-    "import pyiron_core.pyiron_nodes as pn\n",
     "import pyiron_core.pyiron_workflow as pwf\n",
+    "from pyiron_core import nodes\n",
     "from pyiron_core.pyiron_workflow.api import graph as base\n",
     "\n",
     "wf = pwf.Workflow(\"group_returns\")\n",
-    "wf.m = pn.math.Linspace(0,1,2)\n",
+    "wf.m = nodes.math.Linspace(0,1,2)\n",
     "g = base.get_full_graph_from_wf(wf)\n",
     "g = base.create_group(g, [0], label=\"subgraph\")\n",
     "base.pull_node(g, \"subgraph\")"

--- a/pyiron_core/__init__.py
+++ b/pyiron_core/__init__.py
@@ -1,0 +1,1 @@
+import pyiron_core.pyiron_nodes as nodes


### PR DESCRIPTION
And demonstrate usage in user-facing notebook examples. Internally, we stick with referencing the module itself.

I.e.

```python
import pyiron_core.pyiron_workflow as pwf
from pyiron_core import nodes

wf = pwf.Workflow("use_node_package")
wf.m = nodes.math.Linspace(0,1,2)
wf.run()
```