### PR TITLE
Keep binder directory clean

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,3 +1,4 @@
+#!/bin/bash
 pip install . --no-deps --no-build-isolation
 
 # Save the stuff we actually need for binder

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,5 +1,19 @@
 pip install . --no-deps --no-build-isolation
 
+# Save the stuff we actually need for binder
+KEEP=(".binder" "demo")
+mkdir -p ${HOME}/.temp_keep
+for item in "${KEEP[@]}"; do
+    [ -e "${HOME}/${item}" ] && mv "${HOME}/${item}" ${HOME}/.temp_keep/
+done
+
+# Now clean up everything else
+find ${HOME} -mindepth 1 -maxdepth 1 ! -name '.temp_keep' -exec rm -rf {}
+
+# Restore the kept material
+mv ${HOME}/.temp_keep/* ${HOME}/
+rmdir ${HOME}/.temp_keep
+
 # setup customized kernel
 mkdir -p ${HOME}/.local/share/jupyter/kernels/pyiron_core
 cp ${HOME}/.binder/kernel.json ${HOME}/.local/share/jupyter/kernels/pyiron_core
@@ -7,34 +21,9 @@ cp ${HOME}/.binder/kernel.json ${HOME}/.local/share/jupyter/kernels/pyiron_core
 # Bring key content to root
 mv ${HOME}/demo/* .
 
-# clean up
-rm -r   ${HOME}/.binder \
-        ${HOME}/.ci_support \
-        ${HOME}/.github \
-        ${HOME}/__mocks__ \
-        ${HOME}/decisions \
-        ${HOME}/demo \
-        ${HOME}/devbooks \
-        ${HOME}/documentation \
-        ${HOME}/js \
-        ${HOME}/node_modules \
-        ${HOME}/notebooks \
-        ${HOME}/pyiron_core \
-        ${HOME}/stored_workflows \
-        ${HOME}/tests \
-        ${HOME}/.gitignore \
-        ${HOME}/jest.config.js \
-        ${HOME}/jest.config.cjs \
-        ${HOME}/LICENSE \
-        ${HOME}/local_postgres.zsh \
-        ${HOME}/package.json \
-        ${HOME}/package-lock.json \
-        ${HOME}/project-env.yml \
-        ${HOME}/pyproject.toml \
-        ${HOME}/README.md \
-        ${HOME}/setupTests.ts \
-        ${HOME}/tsconfig.json
-
 # download datasets for the demos
 wget https://github.com/pyiron-workshop/DPG-tutorial-2025/raw/351eeca736cce45f9bc3bfca84ab05de049e38c2/data/mgca.pckl.tgz
 wget https://github.com/pyiron-workshop/DPG-tutorial-2025/raw/351eeca736cce45f9bc3bfca84ab05de049e38c2/data/MgCaFreeEnergies.pckl.gz
+
+# Clean up the remaining artifacts of what we kept
+rm -rf ${HOME}/.binder ${HOME}/demo

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -8,7 +8,7 @@ for item in "${KEEP[@]}"; do
 done
 
 # Now clean up everything else
-find ${HOME} -mindepth 1 -maxdepth 1 ! -name '.temp_keep' -exec rm -rf {}
+find ${HOME} -mindepth 1 -maxdepth 1 ! -name '.temp_keep' -exec rm -rf {} +
 
 # Restore the kept material
 mv ${HOME}/.temp_keep/* ${HOME}/


### PR DESCRIPTION
in perpetuity by using a whitelist of what we save instead of manually deleting the content. This way, when other PRs add stuff to ./, the binder home directory doesn't get cluttered.