### PR TITLE
Update GUI on edge removal

### DIFF
--- a/pyiron_core/pyiron_workflow/graph/gui.py
+++ b/pyiron_core/pyiron_workflow/graph/gui.py
@@ -236,7 +236,7 @@ class PyironFlowWidget:
                 elif command == "add_edge":
                     print("add_edge: ", node_name)
                     self.graph += self._parse_edge_string(node_name)
-                    self.main_widget.redraw()
+                    self.update_gui()
                 elif command == "delete_node":
                     print("delete_node: ", node_name)
                     self.graph = base.remove_node(self.graph, node_name)


### PR DESCRIPTION
This causes any now-free ports to revert to their available input state, e.g. to enter new user data.

I also updated from `self.main_widget.redraw()` to `self.update_gui()` on the add-edge case. Experimenting with this change, I didn't see a functional difference, but `update_gui` is snappier and less visually disruptive (no flicker). Additionally, this approach gives better alignment between the different branches of the if clause here, the rest of which use `update_gui` (if anything).