### PR TITLE
setuptools<82 in runtime dependencies

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
 - hatch-jupyter-builder >=0.5.0
+- setuptools <82
 - papermill
 - coverage
 - anywidget =0.9.18

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/pyiron/pyiron_core/graph/badge.svg?token=vJ7abeKoQk)](https://codecov.io/gh/pyiron/pyiron_core)
 [![Test suite](https://github.com/pyiron/pyiron_core/actions/workflows/tests.yml/badge.svg)](https://github.com/pyiron/pyiron_core/actions/workflows/tests.yml)
 
-`pyiron_core` is a workflow management system for Python that leverages a graph-based system -- including a visual scripting GUI -- to develop and execute workflows.
+`pyiron_core` is a workflow management system for Python that leverages a graph-based system -- including a visual scripting GUI -- to develop and execute workflows. 
 
 Key features:
 - **Hybrid workflow creation** -- Code or visual scripting? Mix-and-match text-based and GUI design to best fit where you are in the development process.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/pyiron/pyiron_core/graph/badge.svg?token=vJ7abeKoQk)](https://codecov.io/gh/pyiron/pyiron_core)
 [![Test suite](https://github.com/pyiron/pyiron_core/actions/workflows/tests.yml/badge.svg)](https://github.com/pyiron/pyiron_core/actions/workflows/tests.yml)
 
-`pyiron_core` is a workflow management system for Python that leverages a graph-based system -- including a visual scripting GUI -- to develop and execute workflows. 
+`pyiron_core` is a workflow management system for Python that leverages a graph-based system -- including a visual scripting GUI -- to develop and execute workflows.
 
 Key features:
 - **Hybrid workflow creation** -- Code or visual scripting? Mix-and-match text-based and GUI design to best fit where you are in the development process.

--- a/project-env.yml
+++ b/project-env.yml
@@ -7,6 +7,7 @@ dependencies:
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
 - hatch-jupyter-builder >=0.5.0
+- setuptools <82 # pyace requires older version 
 - papermill  # For testing notebooks generally
 - coverage
 # Platform (pyiron_core/pyiron_workflow, pyironflow, pyiron_database)


### PR DESCRIPTION
pkg_resources is part of setuptools, but got dropped in the version 82 release. 
add setuptools<82 to runtime dependencies.  

This is to fix the CI failure in tests/integration/test_demos.py::TestDemoWorkflows::test_linearfit. 
The traceback shows the failure happens inside the external dependency pyace when RunLinearFit imports it: pyace tries to import pkg_resources and crashes with ModuleNotFoundError: No module named 'pkg_resources' (provided by setuptools).